### PR TITLE
Remove references to International Telephone Input and correct Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Adds Masked input to ACF.
 
 ## Links
 
-* jquery.mask.js[https://github.com/igorescobar/jQuery-Mask-Plugin] by Igor Escobar[https://github.com/igorescobar]
-* Advanced Custom Fields[https://www.advancedcustomfields.com/] by Elliot Condon[https://github.com/elliotcondon]
+* [jquery.mask.js](https://github.com/igorescobar/jQuery-Mask-Plugin) by [Igor Escobar](https://github.com/igorescobar)
+* [Advanced Custom Fields](https://www.advancedcustomfields.com/) by [Elliot Condon](https://github.com/elliotcondon)
 
 ## Compatibility
 
@@ -15,8 +15,8 @@ This ACF field type is compatible with:
 ## Installation 
 
 1. Copy the `acf-masked-input` folder into your `wp-content/plugins` folder
-2. Activate the International Telephone Input plugin via the plugins admin page
-3. Create a new field via ACF and select the International Telephone Input type
+2. Activate the ACF Masked Input plugin via the plugins admin page
+3. Create a new field via ACF and select the ACF Masked Input type
 4. Read the description above for usage instructions
 
 ## Changelog

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Advanced Custom Fields: Masked Input ===
 Contributors: Jony Hayama
-Tags: acf, acf-pro, intl-tel-input
+Tags: acf, acf-pro, acf-masked-input
 Requires at least: 3.6.0
 Tested up to: 4.9.0
 Stable tag: trunk
@@ -14,8 +14,8 @@ Adds Masked input to ACF.
 Adds Masked input to ACF.
 
 = Links =
-* jquery.mask.js[https://github.com/igorescobar/jQuery-Mask-Plugin] by Igor Escobar[https://github.com/igorescobar]
-* Advanced Custom Fields[https://www.advancedcustomfields.com/] by Elliot Condon[https://github.com/elliotcondon]
+* [jquery.mask.js](https://github.com/igorescobar/jQuery-Mask-Plugin) by [Igor Escobar](https://github.com/igorescobar)
+* [Advanced Custom Fields](https://www.advancedcustomfields.com/) by [Elliot Condon](https://github.com/elliotcondon)
 
 = Compatibility =
 
@@ -25,8 +25,8 @@ This ACF field type is compatible with:
 == Installation ==
 
 1. Copy the `acf-masked-input` folder into your `wp-content/plugins` folder
-2. Activate the International Telephone Input plugin via the plugins admin page
-3. Create a new field via ACF and select the International Telephone Input type
+2. Activate the ACF Masked Input plugin via the plugins admin page
+3. Create a new field via ACF and select the ACF Masked Input type
 4. Read the description above for usage instructions
 
 == Changelog ==


### PR DESCRIPTION
There were references to International Telephone Input in the README files and the markdown of the links was incorrect